### PR TITLE
fix(ci): add integrity hash to xlsx CDN tarball lockfile entry

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1771,7 +1771,7 @@ packages:
     engines: {node: '>=20'}
 
   xlsx@https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz:
-    resolution: {tarball: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz}
+    resolution: {tarball: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz, integrity: sha512-oLDq3jw7AcLqKWH2AhCpVTZl8mf6X2YReP+Neh0SJUzV/BdZYjth94tG5toiMB1PPrYtxOCfaoUCkvtuH+3AJA==}
     version: 0.20.3
     engines: {node: '>=0.8'}
     hasBin: true


### PR DESCRIPTION
## What

The xlsx package is pinned to the SheetJS CDN tarball (`https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz`). Its `pnpm-lock.yaml` entry had no `integrity` field.

## Why

When the pnpm store cache is cold -- exactly the CI condition (`pnpm cache is not found` in the logs) -- pnpm 10 cannot verify the downloaded tarball and aborts with:

```
ERR_PNPM_MISSING_TARBALL_INTEGRITY  Cannot install package "xlsx@...": its lockfile entry has no "integrity" field
```

This broke every build, including the Renovate weekly PR (#67), which was being blamed for a failure that predates it.

## Fix

Inject the real sha512 integrity for the tarball into the single lockfile entry. Surgical: one line changed, no dependency versions touched.

## Testing

- `pnpm store prune && rm -rf node_modules && pnpm install --frozen-lockfile` -> passes (reproduces the cold-cache CI condition)
- `pnpm build` -> passes, xlsx resolves at runtime

Once merged, Renovate #67 rebases clean and goes green.